### PR TITLE
Fix npx command for main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ While it should cover most basic migrations, it's __recommended__ to have a look
 If you're using using `npm` in your project:
 
 ```sh
-npx github:typicode/husky-4-to-5 --package-manager npm
+npx github:typicode/husky-4-to-5#main --package-manager npm
 ```
 
 If you're using using `yarn` in your project:
 
 ```sh
-npx github:typicode/husky-4-to-5 --package-manager yarn
+npx github:typicode/husky-4-to-5#main --package-manager yarn
 ```
 
 ## What it does


### PR DESCRIPTION
The given `npx` command failed for me as follows:

```
$ npx github:typicode/husky-4-to-5 --package-manager yarn
npm ERR! code 1
npm ERR! Command failed: /usr/bin/git checkout master
npm ERR! error: pathspec 'master' did not match any file(s) known to git.
npm ERR!

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/mmior/.npm/_logs/2021-02-09T13_50_24_174Z-debug.log
Install for [ 'github:typicode/husky-4-to-5' ] failed with code 1
```

This is because the default branch for the repository is `main`, not `master`. This simply adds the branch specifier `#main`.